### PR TITLE
Add tox test

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,3 +51,5 @@ Patches and Suggestions
 - Achim Herwig <python@wodca.de>
 
 - Ryan Ashley <rashley-iqt>
+
+- Sam Bull (@greatestape)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,14 @@
+import pytest
+
+try:
+    import OpenSSL
+except ImportError:
+    OPENSSL_AVAILABLE = False
+else:
+    OPENSSL_AVAILABLE = True
+
+@pytest.mark.skipif(OPENSSL_AVAILABLE,
+                reason="Requires OpenSSL to be missing to test fallback")
+def test_pyopensslcontext_is_none_when_package_missing():
+    import requests_toolbelt._compat
+    assert requests_toolbelt._compat.PyOpenSSLContext is None

--- a/tests/test_x509_adapter.py
+++ b/tests/test_x509_adapter.py
@@ -35,7 +35,7 @@ class TestX509Adapter(unittest.TestCase):
     @pytest.mark.skipif(not REQUESTS_SUPPORTS_SSL_CONTEXT,
                     reason="Requires Requests v2.12.0 or later")
     @pytest.mark.skipif(not OPENSSL_AVAILABLE,
-                    reason="Requires OpenSSL to be missing to test fallback")
+                    reason="Requires OpenSSL")
     def test_x509_pem(self):
         p12 = load_pkcs12(self.pkcs12_data, self.pkcs12_password_bytes)
         cert_bytes = p12.get_certificate().to_cryptography().public_bytes(Encoding.PEM)
@@ -57,7 +57,7 @@ class TestX509Adapter(unittest.TestCase):
     @pytest.mark.skipif(not REQUESTS_SUPPORTS_SSL_CONTEXT,
                     reason="Requires Requests v2.12.0 or later")
     @pytest.mark.skipif(not OPENSSL_AVAILABLE,
-                    reason="Requires OpenSSL to be missing to test fallback")
+                    reason="Requires OpenSSL")
     def test_x509_der(self):
         p12 = load_pkcs12(self.pkcs12_data, self.pkcs12_password_bytes)
         cert_bytes = p12.get_certificate().to_cryptography().public_bytes(Encoding.DER)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pypy,{py27,py34}-flake8,docstrings
+envlist = py27,py34,py35,py36,pypy,{py27,py34}-flake8,py36-noopenssl,docstrings
 
 [testenv]
 pip_pre = False
@@ -11,6 +11,18 @@ deps =
     ndg-httpsclient
     betamax>0.5.0
 commands = 
+    py.test {posargs}
+
+[testenv:py36-noopenssl]
+pip_pre = False
+deps =
+    requests{env:REQUESTS_VERSION:>=2.0.1,<3.0.0}
+    pytest
+    mock
+    ndg-httpsclient
+    betamax>0.5.0
+commands =
+    pip uninstall -y pyopenssl
     py.test {posargs}
 
 [testenv:py27-flake8]


### PR DESCRIPTION
This adds:

- another tox environment that explicitly excludes `pyopenssl`.
- a test that the `_compat` package doesn't blow up when openssl is missing
- skip decorators on a couple other tests that do need openssl to run